### PR TITLE
Support translating struct updates to Bluespec. Refs #10.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2024-07-11
+        * Support translating Copilot struct updates to Bluespec (#10).
         * Fix a bug in the translation of the signum function. (#14)
         * Fix a bug in the translation of floating-point comparisons. (#15)
 

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.5
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 3.19   && < 3.20
+                          , copilot-core      >= 3.20   && < 3.21
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec

--- a/src/Copilot/Compile/Bluespec/Expr.hs
+++ b/src/Copilot/Compile/Bluespec/Expr.hs
@@ -138,6 +138,11 @@ transOp2 op e1 e2 =
     BwShiftL _ _ -> app $ BS.idLshAt BS.NoPos
     BwShiftR _ _ -> app $ BS.idRshAt BS.NoPos
     Index    _   -> cIndexVector e1 e2
+    UpdateField (Struct _) _ f ->
+      let field :: BS.FString
+          field = fromString $ lowercaseName $ accessorName f in
+      BS.CStructUpd e1 [(BS.mkId BS.NoPos field, e2)]
+    UpdateField _ _ _ -> impossible "transOp2" "copilot-bluespec"
 
     -- Unsupported operations (see
     -- https://github.com/B-Lang-org/bsc/discussions/534)


### PR DESCRIPTION
To accomplish this, we leverage Bluespec's functional struct updates. For instance, suppose we have a Copilot struct with fields `x :: Field "x" Int32` and `y :: Field "y" Int32`.  If we update a struct's `x` field to be `42`, then the generated Bluespec code would look roughly like `v { x = 42 }`.

In order to test `UpdateField` (the `copilot-core` representation of struct field updates), we also generalize the test suite infrastructure a bit, as we need to be able to display and read struct values. Thankfully, this proves relatively straightforward.

Fixes #10.