### PR TITLE
Fix the translation of floating-point comparisons. Refs #15.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2024-07-10
+        * Fix a bug in the translation of floating-point comparisons. (#15)
+
 2024-03-08
         * Version bump (3.19). (#5)
         * Create new library for Bluespec backend.

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -58,7 +58,7 @@ library
                           , Copilot.Compile.Bluespec.Settings
                           , Copilot.Compile.Bluespec.Type
 
-test-suite unit-tests
+test-suite tests
   type:
     exitcode-stdio-1.0
 

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -75,6 +75,7 @@ test-suite tests
     , directory
     , HUnit
     , QuickCheck
+    , ieee754
     , pretty
     , process
     , random

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -7,11 +7,11 @@ import Test.Framework (Test, defaultMain)
 -- Internal library modules being tested
 import qualified Test.Copilot.Compile.Bluespec
 
--- | Run all unit tests on copilot-bluespec.
+-- | Run all @copilot-bluespec@ tests.
 main :: IO ()
 main = defaultMain tests
 
--- | All unit tests in copilot-bluespec.
+-- | All @copilot-bluespec@ tests.
 tests :: [Test.Framework.Test]
 tests =
   [ Test.Copilot.Compile.Bluespec.tests

--- a/tests/Test/Copilot/Compile/Bluespec.hs
+++ b/tests/Test/Copilot/Compile/Bluespec.hs
@@ -45,14 +45,16 @@ import Copilot.Compile.Bluespec.External (External (extName), gatherExts)
 
 -- * Constants
 
--- | All unit tests for copilot-bluespec:Copilot.Compile.Bluespec.
+-- | All tests for copilot-bluespec:Copilot.Compile.Bluespec.
 tests :: Test.Framework.Test
 tests =
   testGroup "Copilot.Compile.Bluespec"
-    [ testProperty "Compile specification"               testCompile
-    , testProperty "Compile specification in custom dir" testCompileCustomDir
-    , testProperty "Run specification"                   testRun
-    , testProperty "Run and compare results"             testRunCompare
+    [ testGroup "Unit tests"
+      [ testProperty "Compile specification"               testCompile
+      , testProperty "Compile specification in custom dir" testCompileCustomDir
+      , testProperty "Run specification"                   testRun
+      , testProperty "Run and compare results"             testRunCompare
+      ]
     ]
 
 -- * Individual tests

--- a/tests/Test/Copilot/Compile/Bluespec.hs
+++ b/tests/Test/Copilot/Compile/Bluespec.hs
@@ -31,8 +31,9 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.QuickCheck                      (Arbitrary, Gen, Property,
                                              arbitrary, choose, elements,
                                              forAll, forAllBlind, frequency,
-                                             getPositive, ioProperty, oneof,
-                                             vectorOf, withMaxSuccess, (.&&.))
+                                             getPositive, ioProperty, once,
+                                             oneof, vectorOf, withMaxSuccess,
+                                             (.&&.))
 import Test.QuickCheck.Gen                  (chooseAny, chooseBoundedIntegral)
 
 -- External imports: Copilot
@@ -65,7 +66,7 @@ tests =
 
 -- | Test compiling a spec.
 testCompile :: Property
-testCompile = ioProperty $ do
+testCompile = once $ ioProperty $ do
     tmpDir <- getTemporaryDirectory
     setCurrentDirectory tmpDir
 
@@ -97,7 +98,7 @@ testCompile = ioProperty $ do
 
 -- | Test compiling a spec in a custom directory.
 testCompileCustomDir :: Property
-testCompileCustomDir = ioProperty $ do
+testCompileCustomDir = once $ ioProperty $ do
     tmpDir <- getTemporaryDirectory
     setCurrentDirectory tmpDir
 
@@ -135,7 +136,7 @@ testCompileCustomDir = ioProperty $ do
 --
 -- The actual behavior is ignored.
 testRun :: Property
-testRun = ioProperty $ do
+testRun = once $ ioProperty $ do
     tmpDir <- getTemporaryDirectory
     setCurrentDirectory tmpDir
 
@@ -261,6 +262,7 @@ mkRegressionTest2 op haskellFun vals =
                     ]
         outputs = haskellFun vals1 vals2 in
 
+    once $
     testRunCompareArg
       inputs len outputs spec (typeBluespec t3)
 


### PR DESCRIPTION
Previously, we would translate the Copilot expression `x < y` to the Bluespec expression `x < y`. While this is a nice and direct translation, it unfortunately does not work when `x` or `y` is derived from a register value. (See https://github.com/Copilot-Language/copilot-bluespec/issues/15 for the full story.) There existed similar problems for `(<=)`, `(>)`, and `(>=)`.

We now translate `x < y` to `compareFP x y == LT`, where `compareFP` is an auxiliary function defined in Bluespec's `FloatingPoint` package. This results in the generated Bluespec code being able to compile, and more importantly, the generated code will have the same semantics as Bluespec when one of the arguments is a NaN value.

Fixes #15.