### PR TITLE
Fix `signum` translation. Refs #14.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-2024-07-10
+2024-07-11
+        * Fix a bug in the translation of the signum function. (#14)
         * Fix a bug in the translation of floating-point comparisons. (#15)
 
 2024-03-08

--- a/tests/Test/Copilot/Compile/Bluespec.hs
+++ b/tests/Test/Copilot/Compile/Bluespec.hs
@@ -220,7 +220,7 @@ testRunCompare =
 -- ('<='), ('>'), and ('>=')) that are capable of handling NaN values.
 test15 :: Test.Framework.Test
 test15 =
-    testGroup "#15"
+  testGroup "#15"
     [ testProperty "Generates valid (<) code for NaNs" $
       mkRegressionTest2 (Lt Double) (zipWith (<)) vals
     , testProperty "Generates valid (<=) code for NaNs" $


### PR DESCRIPTION
This ensures that the translation of Copilot `signum` expressions results in Bluespec code that is semantically equivalent. In particular, it ensures that `signum e` behaves correctly when `e` is zero, negative zero, or `NaN` (if `e` is a floating-point type).

The new translation is heavily inspired by the existing approach in `copilot-c99`: https://github.com/Copilot-Language/copilot/blob/6034e6d4d95464397ba81e346f40f71213c0ffbd/copilot-c99/src/Copilot/Compile/C99/Expr.hs#L233-L272

Fixes #14.