### PR TITLE
CI: Build against GHC 9.4 through 9.8. Refs #20.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        ghc-version: ["8.10.7", "9.2.8", "9.4.8"]
-        cabal: [ '3.10.2.0' ]
+        ghc-version: ["9.4.8", "9.6.6", "9.8.2"]
+        cabal: [ '3.10.3.0' ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2024-08-03
+        * Test GHC 9.4 through 9.8. (#20)
+
 2024-07-11
         * Version bump (3.20). (#11)
         * Support translating Copilot struct updates to Bluespec (#10).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget https://downloads.haskell.org/~ghcup/$GHCUP_VER/x86_64-linux-ghcup-$GHC
 
 ENV PATH=/root/bsc/bin:/root/.cabal/bin:/root/.ghcup/bin:$PATH
 
-ENV GHC_VER=9.2.8
+ENV GHC_VER=9.4.8
 ENV CABAL_VER=3.8.1.0
 RUN ghcup install ghc $GHC_VER && \
     ghcup set ghc $GHC_VER && \


### PR DESCRIPTION
Also update the Dockerfile accordingly.

Fixes #20.