### PR TITLE
Translate array updates to Bluespec. Refs #19.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2024-09-09
+        * Support translating Copilot array updates to Bluespec. (#19)
+
 2024-08-03
         * Test GHC 9.4 through 9.8. (#20)
 

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.5
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 3.20   && < 3.21
+                          , copilot-core      >= 4.0    && < 4.1
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -75,6 +75,7 @@ test-suite tests
     , directory
     , HUnit
     , QuickCheck
+    , extra
     , ieee754
     , pretty
     , process


### PR DESCRIPTION
This adds the necessary code to translate Copilot expressions that update an element of an array to Bluespec, via Bluespec's `update` function (for function array updates). This leverages the same logic for initializing vectors one element at a time using `update`, so this also factors out the code that is shared in common.

Fixes #19.