### PR TITLE
Require building with `copilot-core-4.1`. Refs #25.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-08
+        * Version bump (4.1). (#25)
+
 2024-09-09
         * Version bump (4.0). (#23)
         * Support translating Copilot array updates to Bluespec. (#19)

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-bluespec
-version                   : 4.0
+version                   : 4.1
 synopsis                  : A compiler for Copilot targeting FPGAs.
 description               :
   This package is a back-end from Copilot to FPGAs in Bluespec.
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.5
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 4.0    && < 4.1
+                          , copilot-core      >= 4.1    && < 4.2
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec


### PR DESCRIPTION
Fixes #25.