### PR TITLE
Implement missing/buggy FP operations with `import "BDPI"`. Refs #28.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2024-11-11
+        * Implement missing floating-point operations. (#28)
+
 2024-11-08
         * Version bump (4.1). (#25)
 

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -54,6 +54,7 @@ library
                           , Copilot.Compile.Bluespec.Error
                           , Copilot.Compile.Bluespec.Expr
                           , Copilot.Compile.Bluespec.External
+                          , Copilot.Compile.Bluespec.FloatingPoint
                           , Copilot.Compile.Bluespec.Name
                           , Copilot.Compile.Bluespec.Settings
                           , Copilot.Compile.Bluespec.Type

--- a/src/Copilot/Compile/Bluespec/Compile.hs
+++ b/src/Copilot/Compile/Bluespec/Compile.hs
@@ -27,6 +27,7 @@ import Copilot.Core
 -- Internal imports
 import Copilot.Compile.Bluespec.CodeGen
 import Copilot.Compile.Bluespec.External
+import Copilot.Compile.Bluespec.FloatingPoint
 import Copilot.Compile.Bluespec.Name
 import Copilot.Compile.Bluespec.Settings
 
@@ -53,6 +54,8 @@ compileWith bsSettings prefix spec
        createDirectoryIfMissing True dir
        writeFile (dir </> specTypesPkgName prefix ++ ".bs") typesBsFile
        writeFile (dir </> specIfcPkgName prefix ++ ".bs") ifcBsFile
+       writeFile (dir </> "bs_fp.c") copilotBluespecFloatingPointC
+       writeFile (dir </> "BluespecFP.bsv") copilotBluespecFloatingPointBSV
        writeFile (dir </> prefix ++ ".bs") bsFile
 
 -- | Compile a specification to a Bluespec.
@@ -106,6 +109,7 @@ compileBS _bsSettings prefix spec =
                         $ specTypesPkgName prefix
       , BS.CImpId False $ BS.mkId BS.NoPos $ fromString
                         $ specIfcPkgName prefix
+      , BS.CImpId False $ BS.mkId BS.NoPos "BluespecFP"
       ]
 
     moduleDef :: BS.CDefn

--- a/src/Copilot/Compile/Bluespec/FloatingPoint.hs
+++ b/src/Copilot/Compile/Bluespec/FloatingPoint.hs
@@ -1,0 +1,171 @@
+-- | Generate definitions that allow importing C implementations of
+-- floating-point operations into Bluespec.
+module Copilot.Compile.Bluespec.FloatingPoint
+  ( copilotBluespecFloatingPointBSV
+  , copilotBluespecFloatingPointC
+  ) where
+
+-- | The contents of the generated @BluespecFP.bsv@ file, which contains the
+-- @import \"BDPI\"@ declarations needed to use imported C functions in
+-- Bluespec.
+copilotBluespecFloatingPointBSV :: String
+copilotBluespecFloatingPointBSV =
+  unlines $
+    [ "import FloatingPoint::*;"
+    , ""
+    ] ++
+    concatMap
+      (\funName -> [importOp1 Float funName, importOp1 Double funName])
+      unaryFloatOpNames ++
+    concatMap
+      (\funName -> [importOp2 Float funName, importOp2 Double funName])
+      [ "pow"
+      , "atan2"
+      , "logb"
+      ]
+  where
+    importOp1 :: FloatType -> String -> String
+    importOp1 ft funName =
+      "import \"BDPI\" function " ++ floatTypeName ft ++ " " ++ funNamePrefix
+        ++ funName ++ floatTypeSuffix ft ++ " (" ++ floatTypeName ft ++ " x);"
+
+    importOp2 :: FloatType -> String -> String
+    importOp2 ft funName =
+      "import \"BDPI\" function " ++ floatTypeName ft ++ " " ++ funNamePrefix
+        ++ funName ++ floatTypeSuffix ft ++ " (" ++ floatTypeName ft ++ " x, "
+        ++ floatTypeName ft ++ " y);"
+
+    floatTypeName :: FloatType -> String
+    floatTypeName Float  = "Float"
+    floatTypeName Double = "Double"
+
+-- | The contents of the generated @bs_fp.c@ file, which contains the C wrapper
+-- functions that Bluespec imports.
+copilotBluespecFloatingPointC :: String
+copilotBluespecFloatingPointC =
+  unlines $
+    [ "#include <math.h>"
+    , ""
+    , defineUnionType Float
+    , defineUnionType Double
+    ] ++
+    concatMap
+      (\funName -> [defineOp1 Float funName, defineOp1 Double funName])
+      unaryFloatOpNames ++
+    concatMap
+      (\funName -> [defineOp2 Float funName, defineOp2 Double funName])
+      [ "pow"
+      , "atan2"
+      ] ++
+    -- There is no direct C counterpart to the `logb` function, so we implement
+    -- it in terms of `log`.
+    map
+      (\ft ->
+        defineOp2Skeleton ft "logb" $
+        \_cFunName x y -> "log" ++ floatTypeSuffix ft ++ "(" ++ y ++ ") / log"
+                            ++ floatTypeSuffix ft ++ "( " ++ x ++ ")")
+      [Float, Double]
+  where
+    defineUnionType :: FloatType -> String
+    defineUnionType ft =
+      unlines
+        [ "union " ++ unionTypeName ft ++ " {"
+        , "  " ++ integerTypeName ft ++ " i;"
+        , "  " ++ floatTypeName ft ++ " f;"
+        , "};"
+        ]
+
+    defineOp1Skeleton ::
+      FloatType -> String -> (String -> String -> String) -> String
+    defineOp1Skeleton ft funName mkFloatOp =
+      let cFunName = funName ++ floatTypeSuffix ft in
+      unlines
+        [ integerTypeName ft ++ " "
+          ++ funNamePrefix ++ cFunName
+          ++ "(" ++ integerTypeName ft ++ " x) {"
+        , "  union " ++ unionTypeName ft ++ " x_u;"
+        , "  union " ++ unionTypeName ft ++ " r_u;"
+        , "  x_u.i = x;"
+        , "  r_u.f = " ++ mkFloatOp cFunName "x_u.f" ++ ";"
+        , "  return r_u.i;"
+        , "}"
+        ]
+
+    defineOp1 :: FloatType -> String -> String
+    defineOp1 ft funName =
+      defineOp1Skeleton ft funName $
+      \cFunName x -> cFunName ++ "(" ++ x ++ ")"
+
+    defineOp2Skeleton ::
+      FloatType -> String -> (String -> String -> String -> String) -> String
+    defineOp2Skeleton ft funName mkFloatOp =
+      let cFunName = funName ++ floatTypeSuffix ft in
+      unlines
+        [ integerTypeName ft ++ " "
+          ++ funNamePrefix ++ cFunName
+          ++ "(" ++ integerTypeName ft ++ " x, " ++ integerTypeName ft
+          ++ " y) {"
+        , "  union " ++ unionTypeName ft ++ " x_u;"
+        , "  union " ++ unionTypeName ft ++ " y_u;"
+        , "  union " ++ unionTypeName ft ++ " r_u;"
+        , "  x_u.i = x;"
+        , "  y_u.i = y;"
+        , "  r_u.f = " ++ mkFloatOp cFunName "x_u.f" "y_u.f" ++ ";"
+        , "  return r_u.i;"
+        , "}"
+        ]
+
+    defineOp2 :: FloatType -> String -> String
+    defineOp2 ft funName =
+      defineOp2Skeleton ft funName $
+      \cFunName x y -> cFunName ++ "(" ++ x ++ ", " ++ y ++ ")"
+
+    integerTypeName :: FloatType -> String
+    integerTypeName Float  = "unsigned int"
+    integerTypeName Double = "unsigned long long"
+
+    floatTypeName :: FloatType -> String
+    floatTypeName Float  = "float"
+    floatTypeName Double = "double"
+
+    unionTypeName :: FloatType -> String
+    unionTypeName Float  = "ui_float"
+    unionTypeName Double = "ull_double"
+
+-- * Internals
+
+-- | Are we generating a function for a @float@ or @double@ operation?
+data FloatType
+  = Float
+  | Double
+
+-- | The suffix to use in the generated function.
+floatTypeSuffix :: FloatType -> String
+floatTypeSuffix Float  = "f"
+floatTypeSuffix Double = ""
+
+-- | The prefix to use in the generated function.
+funNamePrefix :: String
+funNamePrefix = "bs_fp_"
+
+-- | The names of unary floating-point operations.
+unaryFloatOpNames :: [String]
+unaryFloatOpNames =
+  [ "exp"
+  , "log"
+  , "acos"
+  , "asin"
+  , "atan"
+  , "cos"
+  , "sin"
+  , "tan"
+  , "acosh"
+  , "asinh"
+  , "atanh"
+  , "cosh"
+  , "sinh"
+  , "tanh"
+  , "ceil"
+  , "floor"
+  , "sqrt"
+  ]

--- a/tests/Test/Copilot/Compile/Bluespec.hs
+++ b/tests/Test/Copilot/Compile/Bluespec.hs
@@ -438,8 +438,22 @@ arbitraryStructUpdate = elements
 -- | Generator of functions on Floating point numbers.
 arbitraryOpFloat :: (Floating t, Typed t) => Gen (Fun t t, [t] -> [t])
 arbitraryOpFloat = elements
-  [ (Op1 (Sqrt typeOf),  fmap sqrt)
-  , (Op1 (Recip typeOf), fmap recip)
+  [ (Op1 (Recip typeOf), fmap recip)
+  , (Op1 (Exp typeOf),   fmap exp)
+  , (Op1 (Sqrt typeOf),  fmap sqrt)
+  , (Op1 (Log typeOf),   fmap log)
+  , (Op1 (Sin typeOf),   fmap sin)
+  , (Op1 (Tan typeOf),   fmap tan)
+  , (Op1 (Cos typeOf),   fmap cos)
+  , (Op1 (Asin typeOf),  fmap asin)
+  , (Op1 (Atan typeOf),  fmap atan)
+  , (Op1 (Acos typeOf),  fmap acos)
+  , (Op1 (Sinh typeOf),  fmap sinh)
+  , (Op1 (Tanh typeOf),  fmap tanh)
+  , (Op1 (Cosh typeOf),  fmap cosh)
+  , (Op1 (Asinh typeOf), fmap asinh)
+  , (Op1 (Atanh typeOf), fmap atanh)
+  , (Op1 (Acosh typeOf), fmap acosh)
   ]
 
 -- | Generator of functions on that produce elements of any type.
@@ -1148,9 +1162,11 @@ compileBluespec baseName extraArgs = do
 -- | Compile a Bluespec file into an executable given its basename.
 compileExecutable :: String -> IO Bool
 compileExecutable topExe = do
-  result <- catch (do callProcess "bsc" $ [ "-sim", "-quiet" ]
-                                          ++ [ "-e", topExe ]
-                                          ++ [ "-o", topExe ]
+  result <- catch (do callProcess "bsc" [ "-sim", "-quiet"
+                                        , "-e", topExe
+                                        , "-o", topExe
+                                        , "bs_fp.c"
+                                        ]
                       return True
                   )
                   (\e -> do


### PR DESCRIPTION
This implements `exp`, `log`, etc. (which were previously missing in `copilot-bluespec`) as well as `sqrt` (which was previously buggy) using Bluespec's `import "BDPI"` feature, allowing these operations to be implemented in terms of C code. While not the most performant implementations around, these are much more likely to be correct than hand-written code. We can work on improving the performance of these operations in future work.

Fixes #28.