### PR TITLE
Allow multiple triggers with the same name. Refs #30.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-2024-11-11
+2025-01-20
         * Implement missing floating-point operations. (#28)
+        * Allow using same trigger name in multiple declarations. (#30)
 
 2024-11-08
         * Version bump (4.1). (#25)

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -56,6 +56,7 @@ library
                           , Copilot.Compile.Bluespec.External
                           , Copilot.Compile.Bluespec.FloatingPoint
                           , Copilot.Compile.Bluespec.Name
+                          , Copilot.Compile.Bluespec.Representation
                           , Copilot.Compile.Bluespec.Settings
                           , Copilot.Compile.Bluespec.Type
 

--- a/src/Copilot/Compile/Bluespec/Representation.hs
+++ b/src/Copilot/Compile/Bluespec/Representation.hs
@@ -1,0 +1,22 @@
+-- | Bluespec backend specific versions of selected `Copilot.Core` datatypes.
+module Copilot.Compile.Bluespec.Representation
+    ( UniqueTrigger (..)
+    , UniqueTriggerId
+    , mkUniqueTriggers
+    )
+  where
+
+import Copilot.Core ( Trigger (..) )
+
+-- | Internal unique name for a trigger.
+type UniqueTriggerId = String
+
+-- | A `Copilot.Core.Trigger` with an unique name.
+data UniqueTrigger = UniqueTrigger UniqueTriggerId Trigger
+
+-- | Given a list of triggers, make their names unique.
+mkUniqueTriggers :: [Trigger] -> [UniqueTrigger]
+mkUniqueTriggers ts = zipWith mkUnique ts [0..]
+  where
+    mkUnique :: Trigger -> Integer -> UniqueTrigger
+    mkUnique t@(Trigger name _ _) n = UniqueTrigger (name ++ "_" ++ show n) t


### PR DESCRIPTION
`copilot-c99-4.2` (part of the overall Copilot 4.2 release) now allows multiple triggers with the same handler, provided that the triggers always have the same type signatures. See https://github.com/Copilot-Language/copilot/issues/296 (as well as the fix in https://github.com/Copilot-Language/copilot/pull/572). Since `copilot-bluespec` wishes to achieve feature parity with `copilot-c99`, we would like to add this ability to `copilot-bluespec` as well.

This commit adds multiple triggers support for `copilot-bluespec`, piggybacking off of the implementation in https://github.com/Copilot-Language/copilot/pull/572.

Fixes #30.