### PR TITLE
Require building with `copilot-core-4.2`. Refs #31.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2025-01-20
+        * Version bump (4.2). (#31)
         * Implement missing floating-point operations. (#28)
         * Allow using same trigger name in multiple declarations. (#30)
 

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-bluespec
-version                   : 4.1
+version                   : 4.2
 synopsis                  : A compiler for Copilot targeting FPGAs.
 description               :
   This package is a back-end from Copilot to FPGAs in Bluespec.
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.5
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 4.1    && < 4.2
+                          , copilot-core      >= 4.2    && < 4.3
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec


### PR DESCRIPTION
Fixes #31.