### PR TITLE
 Require building with `copilot-core-4.3`. Refs #34. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2025-03-10
+        * Version bump (4.3). (#34)
+
 2025-01-20
         * Version bump (4.2). (#31)
         * Implement missing floating-point operations. (#28)

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-bluespec
-version                   : 4.2
+version                   : 4.3
 synopsis                  : A compiler for Copilot targeting FPGAs.
 description               :
   This package is a back-end from Copilot to FPGAs in Bluespec.
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.5
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 4.2    && < 4.3
+                          , copilot-core      >= 4.3    && < 4.4
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec


### PR DESCRIPTION
Fixes #34.