### PR TITLE
Allow building with `filepath-1.5.*`. Refs #39.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 2025-03-20
         * Move Copilot.Compile.Bluespec.External out of shared directory. (#36)
+        * Allow building with filepath-1.5.*. (#39)
 
 2025-03-10
         * Version bump (4.3). (#34)

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -41,7 +41,7 @@ library
   ghc-options             : -Wall
   build-depends           : base              >= 4.9    && < 5
                           , directory         >= 1.3    && < 1.4
-                          , filepath          >= 1.4    && < 1.5
+                          , filepath          >= 1.4    && < 1.6
                           , pretty            >= 1.1.2  && < 1.2
 
                           , copilot-core      >= 4.3    && < 4.4


### PR DESCRIPTION
This allows `copilot-bluespec` to build with the version of `filepath` bundled with GHC 9.10 or later.

Fixes #39.