### PR TITLE
 Require building with `copilot-core-4.4`. Refs #43. 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2025-05-08
+        * Version bump (4.4). (#43)
+
 2025-05-05
         * Version bump (4.3.1). (#41)
         * Move Copilot.Compile.Bluespec.External out of shared directory. (#36)

--- a/copilot-bluespec.cabal
+++ b/copilot-bluespec.cabal
@@ -1,6 +1,6 @@
 cabal-version             : >= 1.10
 name                      : copilot-bluespec
-version                   : 4.3.1
+version                   : 4.4
 synopsis                  : A compiler for Copilot targeting FPGAs.
 description               :
   This package is a back-end from Copilot to FPGAs in Bluespec.
@@ -44,7 +44,7 @@ library
                           , filepath          >= 1.4    && < 1.6
                           , pretty            >= 1.1.2  && < 1.2
 
-                          , copilot-core      >= 4.3    && < 4.4
+                          , copilot-core      >= 4.4    && < 4.5
                           , language-bluespec >= 0.1    && < 0.2
 
   exposed-modules         : Copilot.Compile.Bluespec


### PR DESCRIPTION
Fixes #43.